### PR TITLE
Prevent users from deactivating Ranger rule

### DIFF
--- a/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RangerSparkAuthorizerExtension.scala
+++ b/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RangerSparkAuthorizerExtension.scala
@@ -27,7 +27,6 @@ import org.apache.spark.sql.execution.datasources.{CreateTempViewUsing, InsertIn
 import org.apache.spark.sql.execution.{RangerShowDatabasesCommand, RangerShowTablesCommand, RangerSparkPlanOmitStrategy}
 import org.apache.spark.sql.hive.PrivilegesBuilder
 import org.apache.spark.sql.hive.execution.CreateHiveTableAsSelectCommand
-import scala.reflect.runtime.{universe => ru}
 
 /**
  * An Optimizer Rule to do Hive Authorization V2 for Spark SQL.
@@ -97,10 +96,10 @@ case class RangerSparkAuthorizerExtension(spark: SparkSession) extends Rule[Logi
   }
 
   private def containsRangerExtension(excluded: String) = {
-      excluded.contains(ru.typeTag[RangerSparkAuthorizerExtension].tpe.toString) ||
-        excluded.contains(ru.typeTag[RangerSparkRowFilterExtension].tpe.toString) ||
-        excluded.contains(ru.typeTag[RangerSparkMaskingExtension].tpe.toString) ||
-        excluded.contains(ru.typeTag[RangerSparkPlanOmitStrategy].tpe.toString)
+    excluded.contains(classOf[RangerSparkAuthorizerExtension].getName) ||
+        excluded.contains(classOf[RangerSparkRowFilterExtension].getName) ||
+        excluded.contains(classOf[RangerSparkMaskingExtension].getName) ||
+        excluded.contains(classOf[RangerSparkPlanOmitStrategy].getName)
   }
 
   /**

--- a/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RangerSparkAuthorizerExtensionTest.scala
+++ b/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RangerSparkAuthorizerExtensionTest.scala
@@ -21,6 +21,7 @@ import org.apache.ranger.authorization.spark.authorizer.SparkAccessControlExcept
 import org.apache.spark.sql.hive.test.TestHive
 import org.scalatest.FunSuite
 import org.apache.spark.sql.RangerSparkTestUtils._
+import org.apache.spark.sql.execution.command.SetCommand
 import org.apache.spark.sql.execution.{RangerShowDatabasesCommand, RangerShowTablesCommand}
 
 class RangerSparkAuthorizerExtensionTest extends FunSuite {
@@ -32,6 +33,20 @@ class RangerSparkAuthorizerExtensionTest extends FunSuite {
     val plan = df.queryExecution.optimizedPlan
     val newPlan = extension.apply(plan)
     assert(newPlan.isInstanceOf[RangerShowTablesCommand])
+    assert(extension.apply(newPlan) === newPlan)
+  }
+
+  test("ranger rule can not be excluded via a set command") {
+    val df = spark.sql("SET spark.sql.optimizer.excludedRules=org.apache.spark.sql.catalyst.optimizer.RangerSparkAuthorizerExtension")
+
+    intercept[SparkAccessControlException](extension.apply(df.queryExecution.optimizedPlan))
+  }
+
+  test("non ranger rules can be excluded via a set command") {
+    val df = spark.sql("SET spark.sql.optimizer.excludedRules=some.namespace.classname")
+    val plan = df.queryExecution.optimizedPlan
+    val newPlan = extension.apply(plan)
+    assert(newPlan.isInstanceOf[SetCommand])
     assert(extension.apply(newPlan) === newPlan)
   }
 


### PR DESCRIPTION
As of Spark 2.4, there's a new configuration
(`spark.sql.optimizer.excludedRules`) which allows to exclude some
rules from the optimizer.

This project injects some optimizer rules in order to authorize with
Ranger rules. This caused a security issue where some user could
execute:
`SET spark.sql.optimizer.excludedRules=org.apache.spark.sql.catalyst.optimizer.RangerSparkAuthorizerExtension`

This disables the authorizing rule and allows to bypass all Ranger
rules.

To prevent that, this rule will check if someone tries to disable any
rule which contains the `Ranger` string and will throw an exception. The
unique way to workarround this is that this configuration is set at
Spark level. In this case, we consider it a bad configuration of the
cluster operator.