### PR TITLE
Add support for ranger 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,10 @@ jobs:
       language: scala
       script:
         - mvn clean install -Pspark-2.3 -Pranger-1.2 -Dmaven.javadoc.skip=true -B -V
+    - stage: spark2.3-ranger-2.0
+      language: scala
+      script:
+        - mvn clean install -Pspark-2.3 -Pranger-2.0 -Dmaven.javadoc.skip=true -B -V
     - stage: spark2.4-ranger-1.0
       language: scala
       script:
@@ -54,6 +58,10 @@ jobs:
       language: scala
       script:
         - mvn clean install -Pspark-2.4 -Pranger-1.2 -Dmaven.javadoc.skip=true -B -V
+    - stage: spark2.4-ranger-2.0
+      language: scala
+      script:
+        - mvn clean install -Pspark-2.4 -Pranger-2.0 -Dmaven.javadoc.skip=true -B -V
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Currently, available profiles are:
 
 Spark: -Pspark-2.3, -Pspark2.4
 
-Ranger: -Pranger-1.0, -Pranger-1.1, -Pranger-1.2
+Ranger: -Pranger-1.0, -Pranger-1.1, -Pranger-1.2 -Pranger-2.0
 
 ## Usage
 

--- a/src/test/scala/org/apache/ranger/services/spark/RangerAdminClientImpl.scala
+++ b/src/test/scala/org/apache/ranger/services/spark/RangerAdminClientImpl.scala
@@ -22,10 +22,10 @@ import java.util
 
 import com.google.gson.GsonBuilder
 import org.apache.commons.logging.{Log, LogFactory}
-import org.apache.ranger.admin.client.RangerAdminClient
+import org.apache.ranger.admin.client.RangerAdminRESTClient
 import org.apache.ranger.plugin.util.{GrantRevokeRequest, ServicePolicies, ServiceTags}
 
-class RangerAdminClientImpl extends RangerAdminClient {
+class RangerAdminClientImpl extends RangerAdminRESTClient {
   private val LOG: Log = LogFactory.getLog(classOf[RangerAdminClientImpl])
   private val cacheFilename = "sparkSql_hive_jenkins.json"
   private val gson =


### PR DESCRIPTION
As mentioned in https://github.com/yaooqinn/spark-ranger/issues/4, this PR proposes adding another version of the `RangerAdminClientImpl` with complies with the `RangerAdminClient` interface which has more methods since Ranger 2.0

Changes made:
- added the travis config to build Spark 2.3 and 2.4 using Ranger 2.0
- added maven specific config to specify which Ranger class to use during test-compile
- the `RangerAdminClientImpl` was refactored into a trait so we could extend the original `RangerAdminClient` interface and re-use the trait